### PR TITLE
Compacted update

### DIFF
--- a/DemoLogging.py
+++ b/DemoLogging.py
@@ -76,9 +76,7 @@ def main():
             pass
         else:
             msg = queue_handler.format(record)
-            logText = form.FindElement('Log').Get()
-            logText += msg
-            form.FindElement('Log').Update(logText)
+            form.FindElement('Log').Update(value['Log']+msg)
 
     exit()
 


### PR DESCRIPTION
Since the values returned from the read contain all of the form's elements, there is no need to lookup the values of the multi-line.  You can compact the update into a single statement.
